### PR TITLE
whip: add Location header, docs: add gstreamer to readme + example(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ page will look like this.
 
 When you are ready to broadcast press `Stream Streaming` and now time to watch!
 
+### Broadcasting (Gstreamer, CLI)
+
+See the example script(s):
+  * `examples/gstreamer-broadcast.nu`
+    * can broadcast gstreamer's test sources, or pulsesrc+v4l2src
+    * expects `gstreamer-1.0`, with `good,bad,ugly` plugins and `gst-plugins-rs`
+    * ```shell
+      # testsrcs
+      ./examples/gstreamer-broadcast.nu http://localhost:8080/api/whip testStream1
+      # v4l2src
+      ./examples/gstreamer-broadcast.nu http://localhost:8080/api/whip testStream1 v4l2
+      ```
+
 ### Playback
 
 If you are broadcasting to the Stream Key `StreamTest` your video will be available at https://b.siobud.com/StreamTest.

--- a/examples/gstreamer-broadcast.nu
+++ b/examples/gstreamer-broadcast.nu
@@ -1,0 +1,34 @@
+#!/usr/bin/env nu
+
+def main [ whip_endpoint: string, auth_token: string, stream_type = "testsrc" ] {
+  mut srcelem = []
+  mut audioelem = []
+  
+  if $stream_type == "testsrc" {
+    $srcelem =  [ videotestsrc pattern=smpte-rp-219 ]
+    $audioelem = [ audiotestsrc wave=8 ]
+  } else {
+    $srcelem = [ v4l2src "device=/dev/video1" ]
+    $audioelem = [ pulsesrc "device=alsa_input.usb-MACROSILICON_USB3._0_capture-02.analog-stereo" ]
+  }
+  
+  (gst-launch-1.0 -v
+  $srcelem
+    ! videoconvert
+    ! x264enc tune="zerolatency"
+    ! rtph264pay
+    ! application/x-rtp,media=video,encoding-name=H264,payload=97,clock-rate=90000
+    ! whip0.sink_0
+  $audioelem
+    ! audioconvert
+    ! opusenc
+    ! rtpopuspay
+    ! application/x-rtp,media=audio,encoding-name=OPUS,payload=96,clock-rate=48000,encoding-params=(string)2
+    ! whip0.sink_1
+  whipsink
+    name=whip0
+    use-link-headers=true
+    $"whip-endpoint=($whip_endpoint)"
+    $"auth-token=($auth_token)"
+  )
+}

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ func whipHandler(res http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	res.Header().Add("Location", "/api/whip")
 	res.WriteHeader(http.StatusCreated)
 	fmt.Fprint(res, answer)
 }


### PR DESCRIPTION
* [whip: add Location header to make gstreamer happy](https://github.com/Glimesh/broadcast-box/commit/456c6d1a0884e10cd24008ee2fa927ae63ebf64e)
    * note, it seems broadcast-box doesn't really have a "stream name" and uses the authentication header value as the stream key so this seems as good as any of location to return. From what I can tell, the rest of the "exchange" is all done via SDP, not via the HTTP API, so I don't know that it matters other than gstreamer really wanting it
    * also it seem streamNames are stored as "Bearer <streamName>" internally, not that it matters as-is right now

 * [README/examples: add gstreamer docs+ex](https://github.com/Glimesh/broadcast-box/commit/f01c9620aa5d614af0e8a98fc48a85e24973c171)
   * added a callout in the README but kept the meat in the script itself
   * script is nushell; it made it certain things easy, and I really don't want to port to bash, but I understand if its too much
   * script exercises gstreamer and the `whipsink` plugin
   * tested with:
     *  the `testsrc` sources, outputting steady beeps and a colorbar/test pattern
     * gstreamer on a cheap aarch64 SBC, with a cheap HDMI USB3 (MS2130) capture card broadcasting another computer's A+V; perf for video alone was quite good; less stable after adding audio but I think that's due to my lack of knowledge of Gstreamer.

fixes: #25 