### PR TITLE
add SSL support and Let's Encrtpy sample path

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,9 @@
 HTTP_ADDRESS=":8080"
-REACT_APP_API_PATH="http://localhost:8080/api"
+ENABLE_HTTP_REDIRECT=
+REACT_APP_API_PATH="/api"
+
+# /etc/letsencrypt/live/<your-domain-name>/privkey.pem
+SSL_KEY=
+
+# /etc/letsencrypt/live/<your-domain-name>/fullchain.pem
+SSL_CERT=

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,9 @@
 HTTP_ADDRESS=":8080"
+ENABLE_HTTP_REDIRECT=
 REACT_APP_API_PATH="/api"
+
+# /etc/letsencrypt/live/<your-domain-name>/privkey.pem
+SSL_KEY=
+
+# /etc/letsencrypt/live/<your-domain-name>/fullchain.pem
+SSL_CERT=


### PR DESCRIPTION
I did this for one-stop setting to enable HTTPS, not having HTTPS blocking the camera and microphone access when you deployed to the cloud platforms.

* forward 80 to 443
* SSL serving
* loading SSL key and cert from .env 