### PR TITLE
Add method check to whipHandler

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,27 +42,29 @@ func logHTTPError(w http.ResponseWriter, err string, code int) {
 
 func whipHandler(res http.ResponseWriter, r *http.Request) {
 	streamKey := r.Header.Get("Authorization")
-	if streamKey == "" {
-		logHTTPError(res, "Authorization was not set", http.StatusBadRequest)
-		return
-	}
+	if r.Method == "POST" {
+		if streamKey == "" {
+			logHTTPError(res, "Authorization was not set", http.StatusBadRequest)
+			return
+		}
 
-	offer, err := io.ReadAll(r.Body)
-	if err != nil {
-		logHTTPError(res, err.Error(), http.StatusBadRequest)
-		return
-	}
+		offer, err := io.ReadAll(r.Body)
+		if err != nil {
+			logHTTPError(res, err.Error(), http.StatusBadRequest)
+			return
+		}
 
-	answer, err := webrtc.WHIP(string(offer), streamKey)
-	if err != nil {
-		logHTTPError(res, err.Error(), http.StatusBadRequest)
-		return
-	}
+		answer, err := webrtc.WHIP(string(offer), streamKey)
+		if err != nil {
+			logHTTPError(res, err.Error(), http.StatusBadRequest)
+			return
+		}
 
-	res.Header().Add("Location", "/api/whip")
-	res.Header().Add("Content-Type", "application/sdp")
-	res.WriteHeader(http.StatusCreated)
-	fmt.Fprint(res, answer)
+		res.Header().Add("Location", "/api/whip")
+		res.Header().Add("Content-Type", "application/sdp")
+		res.WriteHeader(http.StatusCreated)
+		fmt.Fprint(res, answer)
+	}
 }
 
 func whepHandler(res http.ResponseWriter, req *http.Request) {

--- a/main.go
+++ b/main.go
@@ -41,30 +41,32 @@ func logHTTPError(w http.ResponseWriter, err string, code int) {
 }
 
 func whipHandler(res http.ResponseWriter, r *http.Request) {
-	streamKey := r.Header.Get("Authorization")
-	if r.Method == "POST" {
-		if streamKey == "" {
-			logHTTPError(res, "Authorization was not set", http.StatusBadRequest)
-			return
-		}
-
-		offer, err := io.ReadAll(r.Body)
-		if err != nil {
-			logHTTPError(res, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		answer, err := webrtc.WHIP(string(offer), streamKey)
-		if err != nil {
-			logHTTPError(res, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		res.Header().Add("Location", "/api/whip")
-		res.Header().Add("Content-Type", "application/sdp")
-		res.WriteHeader(http.StatusCreated)
-		fmt.Fprint(res, answer)
+	if r.Method == "DELETE" {
+		return
 	}
+
+	streamKey := r.Header.Get("Authorization")
+	if streamKey == "" {
+		logHTTPError(res, "Authorization was not set", http.StatusBadRequest)
+		return
+	}
+
+	offer, err := io.ReadAll(r.Body)
+	if err != nil {
+		logHTTPError(res, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	answer, err := webrtc.WHIP(string(offer), streamKey)
+	if err != nil {
+		logHTTPError(res, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	res.Header().Add("Location", "/api/whip")
+	res.Header().Add("Content-Type", "application/sdp")
+	res.WriteHeader(http.StatusCreated)
+	fmt.Fprint(res, answer)
 }
 
 func whepHandler(res http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Add method check to whipHandler to prevent empty streams from being created by OBS users. I believe this is why there are streams listed in /api/status that are broken.

OBS sends a DELETE request when the stream is terminated, see screenshot of packet capture.

![Screenshot_20240124_213501](https://github.com/Glimesh/broadcast-box/assets/13863948/a1828d7c-026b-4f9d-9a28-fbcfeba75786)

I believe the `DELETE` request can safely be ignored as removal of the streamkey/info is handled [here](https://github.com/Glimesh/broadcast-box/blob/main/internal/webrtc/whip.go#L120)

Edit, sorry for the multiple commits, I think an earlier return is more appropriate?

Let me know if there is anything else I can do, thanks.
Chase