### PR TITLE
Silo and scope ci to only run when needed

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+      - '.github/**'
 
 jobs:
   docker:

--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -1,34 +1,36 @@
-name: Lint
+name: Go Lint
 on:
   push:
     branches:
       - main
-  pull_request:
+    paths:
+      - '*.go'
+      - 'go.mod'
+      - 'go.sum'
 
+  pull_request:
+    paths:
+      - '*.go'
+      - 'go.mod'
+      - 'go.sum'
+
+permissions:
+  contents: read
+
+# Avoid adding additional steps to this job. Create a new job instead.
+# https://github.com/golangci/golangci-lint-action/issues/244
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-go@v5
         with:
           go-version: '1.21'
-
+          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
           version: 'latest'
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 'lts/*'
-          cache: 'npm'
-          cache-dependency-path: web/package-lock.json
-
-      - run: npm ci
-        working-directory: web
-
-      - run: npm run lint
-        working-directory: web
+          args: --timeout 5m

--- a/.github/workflows/node-lint.yaml
+++ b/.github/workflows/node-lint.yaml
@@ -1,0 +1,29 @@
+name: Node Lint
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'web/**'
+  pull_request:
+    paths:
+      - 'web/**'
+
+defaults:
+  run:
+    working-directory: web
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 'lts/*'
+        cache: 'npm'
+        cache-dependency-path: web/package-lock.json
+
+    - run: npm ci
+    - run: npm test


### PR DESCRIPTION
I separated the Go and npm lint, so we can take advantage of scoping and have only the appropriate lint run when needed. This may also fix a bug with our lint [example](https://github.com/Glimesh/broadcast-box/actions/runs/7978381908)

If there's any other small correction that needs to be made I will push directly to fix.