### PR TITLE
Fix crash when source disconnects with connected peers

### DIFF
--- a/internal/webrtc/webrtc.go
+++ b/internal/webrtc/webrtc.go
@@ -109,7 +109,7 @@ func peerConnectionDisconnected(streamKey string, whepSessionId string) {
 		return
 	}
 
-	if whepSessionId != "" {
+	if whepSessionId == "" {
 		stream.whepSessionsLock.Lock()
 		defer stream.whepSessionsLock.Unlock()
 		delete(stream.whepSessions, whepSessionId)


### PR DESCRIPTION
I believe we want to enter this condition [if](https://github.com/Glimesh/broadcast-box/blob/main/internal/webrtc/webrtc.go#L112) triggered from a [whip state change](https://github.com/Glimesh/broadcast-box/blob/main/internal/webrtc/whip.go#L124)

Logs
```
2024/02/20 18:09:14 Loading `.env.production`
2024/02/20 18:09:14 Running HTTP Server at `:8080`
panic: send on closed channel

goroutine 132 [running]:
github.com/glimesh/broadcast-box/internal/webrtc.WHEP.func2()
    /home/chase/projects/broadcast-box/cc_broadcast-box/internal/webrtc/whep.go:120 +0x8a
created by github.com/glimesh/broadcast-box/internal/webrtc.WHEP in goroutine 52
    /home/chase/projects/broadcast-box/cc_broadcast-box/internal/webrtc/whep.go:110 +0x373
exit status 2```