### PR TITLE
fix DTLS hello for russia

### DIFF
--- a/internal/webrtc/webrtc.go
+++ b/internal/webrtc/webrtc.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/pion/dtls/v2/pkg/crypto/elliptic"
 	"github.com/pion/ice/v2"
 	"github.com/pion/interceptor"
 	"github.com/pion/webrtc/v4"
@@ -241,6 +242,8 @@ func createSettingEngine(isWHIP bool, udpMuxCache map[int]*ice.MultiUDPMuxDefaul
 
 		settingEngine.SetICETCPMux(webrtc.NewICETCPMux(nil, tcpListener, 8))
 	}
+
+	settingEngine.SetDTLSEllipticCurves(elliptic.X25519, elliptic.P384, elliptic.P256)
 
 	return
 }


### PR DESCRIPTION
russian censorship blocks certain DTLS packets based on signature workaround this by swapping order of encryption elliptic curve ids this swaps bytes in DTLS packets thus evading signature blocking

https://ntc.party/t/a-new-snowflake-blocking-rule-offset-of-supportedgroups-in-dtls-client-hello/2420 (cherry picked from commit 410673660f94acaa084e9cc959082b56495250f1)