### PR TITLE
feature: Add very simple tree display of RTCPeerConnection getStats

### DIFF
--- a/web/src/components/player/index.js
+++ b/web/src/components/player/index.js
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react'
 import { parseLinkHeader } from '@web3-storage/parse-link-header'
 import { useLocation, useSearchParams } from 'react-router-dom'
+import { Statistics } from '../statistics';
 
 export const CinemaModeContext = React.createContext(null);
 
@@ -36,8 +37,9 @@ function PlayerPage() {
 }
 
 function Player({ cinemaMode }) {
-  const videoRef = React.createRef()
-  const location = useLocation()
+  const videoRef = React.createRef();
+  const connectionRef = React.createRef();
+  const location = useLocation();
   const [videoLayers, setVideoLayers] = React.useState([]);
   const [mediaSrcObject, setMediaSrcObject] = React.useState(null);
   const [layerEndpoint, setLayerEndpoint] = React.useState('');
@@ -60,7 +62,7 @@ function Player({ cinemaMode }) {
 
   React.useEffect(() => {
     const peerConnection = new RTCPeerConnection() // eslint-disable-line
-
+    connectionRef.current = peerConnection;
     peerConnection.ontrack = function (event) {
       setMediaSrcObject(event.streams[0])
     }
@@ -104,7 +106,7 @@ function Player({ cinemaMode }) {
     return function cleanup() {
       peerConnection.close()
     }
-  }, [location.pathname])
+  }, [location.pathname, connectionRef])
 
   return (
     <>
@@ -129,6 +131,7 @@ function Player({ cinemaMode }) {
           })}
         </select>
       }
+      <Statistics visible={true} connectionRef={connectionRef} />
     </>
   )
 }

--- a/web/src/components/statistics/TreeNode.js
+++ b/web/src/components/statistics/TreeNode.js
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+
+/**
+ * TreeNode component representing a single node in the expandable tree.
+ * @param {Object} props - The properties passed to the component.
+ * @param {string} props.name - The name of the node.
+ * @param {any} props.value - The value of the node.
+ * @param {Function} props.formatter - A callback function to format the node value.
+ * @param {Array} props.children - An array of child nodes, which are objects of the same type as the parent node.
+ */
+function TreeNode({ name, value, formatter, children }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  /**
+   * Toggle the expansion state of the tree node.
+   */
+  const toggleExpand = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  return (
+    <div>
+      <div onClick={toggleExpand} style={{ fontWeight: 'bold', cursor: 'pointer' }}>
+        {name} {formatter ? formatter(value):value}
+      </div>
+      {isExpanded && (
+        <div style={{ marginLeft: '20px' }}>
+          {children?.map((child, index) => (
+            <TreeNode key={index} {...child} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TreeNode;

--- a/web/src/components/statistics/index.js
+++ b/web/src/components/statistics/index.js
@@ -1,0 +1,67 @@
+import React, { useState, useCallback, useEffect } from "react";
+import TreeNode from "./TreeNode";
+
+/**
+ * @typedef {Object} StatisticsProps
+ * @property {boolean} visible - Whether to display the stats
+ * @property {RTCPeerConnection} connectionRef - The RTCPeerConnection to display stats for
+ */
+/**
+ * @param {StatisticsProps} props
+ */
+export function Statistics(props) {
+  const { visible, connectionRef } = props;
+  /**
+   * @type {ReturnType<typeof useState<setInterval>>}
+   */
+  const [statsInterval, setStatsInterval] = useState(null);
+  const [stats, setStats] = useState({});
+  const updateStats = useCallback(() => {
+    requestAnimationFrame(async () => {
+      try {
+        const { current: connection } = connectionRef;
+        if (!connection) {
+          return;
+        }
+        const stats = await connection.getStats();
+        setStats({
+          name: "RTCStatsReport",
+          children: [...stats.entries()].reduce((acc, [id, dict]) => {
+            acc.push({
+              name: dict.type,
+              children: Object.entries(dict).reduce(
+                (statsAcc, [key, value]) => {
+                  if (key === 'type') return statsAcc;
+                  statsAcc.push({
+                    name: key,
+                    value,
+                  });
+                  return statsAcc;
+                },
+                [],
+              ),
+            });
+            return acc;
+          }, []),
+        });
+      } catch (e) {
+        clearInterval(statsInterval);
+        setStatsInterval(null);
+      }
+    });
+  }, [connectionRef]);
+  useEffect(() => {
+    if (visible) {
+      setInterval(updateStats, 250);
+    } else if (statsInterval) {
+      clearInterval(statsInterval);
+      setStatsInterval(null);
+    }
+    return () => {
+      if (statsInterval) {
+        clearInterval(statsInterval);
+      }
+    };
+  }, [visible, connectionRef, statsInterval]);
+  return <TreeNode {...stats} />;
+}


### PR DESCRIPTION
This PR adds an initial raw tree view of the return value of getStats.

The statistics are updated every 250ms at this time.

@Sean-Der This is basically a raw dump of the getStats dictionary in a tree form. I would like to discuss possible ideas on making this data more useful, including if there is any desire for charting of some of the bitrate or jitter values and how it might be helpful to break out some of the stats to aid in diagnosing WebRTC.