### PR TITLE
Watch stream button default on enter press.

### DIFF
--- a/web/src/components/selection/index.js
+++ b/web/src/components/selection/index.js
@@ -33,7 +33,7 @@ function Selection(props) {
           <input className='appearance-none border w-full py-2 px-3 leading-tight focus:outline-none focus:shadow-outline bg-gray-700 border-gray-700 text-white rounded shadow-md placeholder-gray-200' id='streamKey' type='text' placeholder='Stream Key' onChange={onStreamKeyChange} autoFocus />
         </div>
         <div className='flex'>
-          <button className='py-2 px-4 bg-blue-500 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-75' type='button' onClick={onWatchStreamClick}>
+          <button className='py-2 px-4 bg-blue-500 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-75' type='submit' onClick={onWatchStreamClick}>
             Watch Stream
           </button>
 


### PR DESCRIPTION
Some users had difficulty entering stream key because they were pressing enter in the input field instead of clicking on the button. The form currently erases the typed stream key from the input field by resetting the form on enter press. This PR simply sets the "Watch Stream" button to the default submit action on the form when enter is pressed.