### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ page will look like this.
 
 ![OBS Output settings example](./.github/img/outputPage.png)
 
-When you are ready to broadcast press `Stream Streaming` and now time to watch!
+When you are ready to broadcast press `Start Streaming` and now time to watch!
 
 ### Broadcasting (GStreamer, CLI)
 


### PR DESCRIPTION
`Stream Streaming` -> `Start Streaming`

![image](https://github.com/user-attachments/assets/b5dad465-38cd-4c79-9e1d-c926f577a0d4)
