### PR TITLE
Get proper cinema mode for video streams on large monitors

### DIFF
--- a/web/src/components/player/index.js
+++ b/web/src/components/player/index.js
@@ -111,7 +111,11 @@ function Player({ cinemaMode }) {
         muted
         controls
         playsInline
-        className={`bg-black w-full ${cinemaMode && "min-h-screen"}`}
+        className={`bg-black w-full ${cinemaMode && "h-full"}`}
+        style={cinemaMode && {
+          maxHeight: '100vh',
+          maxWidth: '100vw'
+        } || {}}
       />
 
       {videoLayers.length >= 2 &&


### PR DESCRIPTION
Makes it, so the video element takes up the full width of the monitor on screens larger than 1080p from testing.