### PR TITLE
Fix `DISABLE_STATUS` environment variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -162,6 +162,7 @@ func whepLayerHandler(res http.ResponseWriter, req *http.Request) {
 func statusHandler(res http.ResponseWriter, req *http.Request) {
 	if os.Getenv("DISABLE_STATUS") != "" {
 		logHTTPError(res, "Status Service Unavailable", http.StatusServiceUnavailable)
+		return
 	}
 
 	res.Header().Add("Content-Type", "application/json")


### PR DESCRIPTION
#322 broke `DISABLE_STATUS` meaning stream keys are exposed even with `DISABLE_STATUS` enabled