### PR TITLE
changed some logic regarding restarting a stream, streams being deleted

### DIFF
--- a/internal/webrtc/webrtc.go
+++ b/internal/webrtc/webrtc.go
@@ -65,6 +65,8 @@ type (
 var (
 	streamMap        map[string]*stream
 	streamMapLock    sync.Mutex
+	peerConnectionMap        map[string]*webrtc.PeerConnection
+	peerConnectionMapLock    sync.Mutex
 	apiWhip, apiWhep *webrtc.API
 
 	// nolint
@@ -125,7 +127,7 @@ func peerConnectionDisconnected(streamKey string, whepSessionId string) {
 	if !ok {
 		return
 	}
-
+	
 	stream.whepSessionsLock.Lock()
 	defer stream.whepSessionsLock.Unlock()
 
@@ -136,9 +138,10 @@ func peerConnectionDisconnected(streamKey string, whepSessionId string) {
 		stream.videoTracks = nil
 	}
 
-	// Only delete stream if all WHEP Sessions are gone and have no WHIP Client
-	if len(stream.whepSessions) != 0 || stream.hasWHIPClient.Load() {
-		return
+	// Only delete stream if WHIP Session is gone
+	//if len(stream.whepSessions) != 0 || stream.hasWHIPClient.Load() {
+	if stream.hasWHIPClient.Load() {
+			return
 	}
 
 	stream.whipActiveContextCancel()
@@ -166,11 +169,7 @@ func getPublicIP() string {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer func() {
-		if closeErr := req.Body.Close(); closeErr != nil {
-			log.Fatal(err)
-		}
-	}()
+	defer req.Body.Close()
 
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
@@ -393,6 +392,7 @@ func maybePrintOfferAnswer(sdp string, isOffer bool) string {
 
 func Configure() {
 	streamMap = map[string]*stream{}
+	peerConnectionMap = map[string]*webrtc.PeerConnection{}
 
 	mediaEngine := &webrtc.MediaEngine{}
 	if err := PopulateMediaEngine(mediaEngine); err != nil {

--- a/internal/webrtc/whip.go
+++ b/internal/webrtc/whip.go
@@ -65,7 +65,7 @@ func videoWriter(remoteTrack *webrtc.TrackRemote, stream *stream, peerConnection
 
 	rtpBuf := make([]byte, 1500)
 	rtpPkt := &rtp.Packet{}
-	codec := getVideoTrackCodec(remoteTrack.Codec().MimeType)
+	codec := getVideoTrackCodec(remoteTrack.Codec().RTPCodecCapability.MimeType)
 
 	var depacketizer rtp.Depacketizer
 	switch codec {
@@ -142,10 +142,32 @@ func videoWriter(remoteTrack *webrtc.TrackRemote, stream *stream, peerConnection
 func WHIP(offer, streamKey string) (string, error) {
 	maybePrintOfferAnswer(offer, true)
 
+	
+	//if a stream reconnects too quick, e.g obs stop->start
+	//the ice disconnect->failure event will be *after*
+	//the stream gets added regularly
+	//which results in the replaced stream getting deleted by the oniceconnectionstatechange
+	//that's why we disable and delete the old streams
+	//peerconnection if its being replaced
+	peerConnectionMapLock.Lock()
+	defer peerConnectionMapLock.Unlock()
+	_, ok := streamMap[streamKey]
+	if (ok){
+		//peerConnectionDisconnected(streamKey, "")
+		peerConnectionMap[streamKey].OnICEConnectionStateChange(func(i webrtc.ICEConnectionState) {})
+		peerConnectionMap[streamKey].Close();
+		delete(peerConnectionMap, streamKey)
+	}
+
 	peerConnection, err := newPeerConnection(apiWhip)
 	if err != nil {
 		return "", err
 	}
+
+	//replacing the existing peerconnection for an existing stream
+	//results in dropped connections resuming as well
+	// (although visuals might be impaired until next keyframe)
+	peerConnectionMap[streamKey] = peerConnection
 
 	streamMapLock.Lock()
 	defer streamMapLock.Unlock()
@@ -155,7 +177,7 @@ func WHIP(offer, streamKey string) (string, error) {
 	}
 
 	peerConnection.OnTrack(func(remoteTrack *webrtc.TrackRemote, rtpReceiver *webrtc.RTPReceiver) {
-		if strings.HasPrefix(remoteTrack.Codec().MimeType, "audio") {
+		if strings.HasPrefix(remoteTrack.Codec().RTPCodecCapability.MimeType, "audio") {
 			audioWriter(remoteTrack, stream)
 		} else {
 			videoWriter(remoteTrack, stream, peerConnection, stream)
@@ -164,6 +186,7 @@ func WHIP(offer, streamKey string) (string, error) {
 	})
 
 	peerConnection.OnICEConnectionStateChange(func(i webrtc.ICEConnectionState) {
+		//on network fail: disconnect -> failed
 		if i == webrtc.ICEConnectionStateFailed || i == webrtc.ICEConnectionStateClosed {
 			if err := peerConnection.Close(); err != nil {
 				log.Println(err)


### PR DESCRIPTION
Changed handling of streams being dropped/recreated when reconnecting.
Before if we e.g restart the stream in obs, obs doesn't actually reconnect, it just starts a new stream.
This results in bbox replacing the stream object, but never disposing of the old peerconnection.
The old peerconnection then goes into ICE disconnect->failed and bbox disposes of the stream in the status api.
This PR should fix that so that when a stream with the same streamkey as an existing one is added, it replaces the existing streams peerconnection, and disposes of the old one. Which should result in existing viewers "reconnecting" and the stream staying live in the status api.