### PR TITLE
remove ports from caddy docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,9 +12,6 @@ services:
 
   caddy:
     image: lucaslorentz/caddy-docker-proxy:ci-alpine
-    ports:
-      - 80:80
-      - 443:443
     environment:
       - CADDY_INGRESS_NETWORKS=caddy
     volumes:


### PR DESCRIPTION
The caddy container specifies "host" networking so the ports aren't necessary. Older versions of docker/docker-compose may have just ignored the the ports when using "host" networking, but I was unable to get the containers to start using docker-compose 1.29.2 / docker 20.10.24+dfsg1, build 297e128 as it threw an error around having specified ports AND "host" networking.