### PR TITLE
Enable TCP support in NetworkTest

### DIFF
--- a/internal/networktest/networktest.go
+++ b/internal/networktest/networktest.go
@@ -24,7 +24,15 @@ func Run(whepHandler func(res http.ResponseWriter, req *http.Request)) error {
 		return err
 	}
 
-	peerConnection, err := webrtc.NewAPI(webrtc.WithMediaEngine(m)).NewPeerConnection(webrtc.Configuration{})
+       s := webrtc.SettingEngine{}
+       s.SetNetworkTypes([]webrtc.NetworkType{
+               webrtc.NetworkTypeUDP4,
+               webrtc.NetworkTypeUDP6,
+               webrtc.NetworkTypeTCP4,
+               webrtc.NetworkTypeTCP6,
+       })
+
+       peerConnection, err := webrtc.NewAPI(webrtc.WithMediaEngine(m), webrtc.WithSettingEngine(s)).NewPeerConnection(webrtc.Configuration{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If Broadcast Box only has TCP connectivity the test would incorrectly fail.

Resolves #377