### PR TITLE
Disable Simulcast publish for screenshares on web

### DIFF
--- a/web/src/components/broadcast/Broadcast.tsx
+++ b/web/src/components/broadcast/Broadcast.tsx
@@ -90,7 +90,8 @@ function BrowserBroadcaster() {
 			return
 		}
 
-		const mediaPromise = useDisplayMedia == "Screen" ?
+		const isScreenShare = useDisplayMedia === "Screen"
+		const mediaPromise = isScreenShare ?
 			navigator.mediaDevices.getDisplayMedia(mediaOptions) :
 			navigator.mediaDevices.getUserMedia(mediaOptions)
 
@@ -116,7 +117,7 @@ function BrowserBroadcaster() {
 					} else {
 						peerConnectionRef.current!.addTransceiver(mediaStreamTrack, {
 							direction: 'sendonly',
-							sendEncodings: [
+							sendEncodings: isScreenShare ? [] : [
 								{
 									rid: 'high',
 								},


### PR DESCRIPTION
FireFox doesn't publish any media. Worth investigating more, but fixing by disabling for now.

Resolves #376