### PR TITLE
Visually indicate unavailable player features

### DIFF
--- a/web/src/components/player/Player.tsx
+++ b/web/src/components/player/Player.tsx
@@ -248,8 +248,26 @@ const Player = (props: PlayerProps) => {
 
 							{hasSignal && <CurrentViewersComponent streamKey={streamKey}/>}
 							<QualitySelectorComponent layers={videoLayers} layerEndpoint={layerEndpointRef.current} hasPacketLoss={hasPacketLoss}/>
-							<Square2StackIcon onClick={() => videoRef.current?.requestPictureInPicture()}/>
-							<ArrowsPointingOutIcon onClick={() => videoRef.current?.requestFullscreen()}/>
+							{ videoRef.current?.requestPictureInPicture ?
+								<Square2StackIcon
+									className="cursor-pointer"
+									onClick={() => videoRef.current?.requestPictureInPicture()}
+								/>
+							:
+								<Square2StackIcon
+									className="opacity-25"
+								/>
+							}
+							{ videoRef.current?.requestFullscreen ?
+								<ArrowsPointingOutIcon
+									className="cursor-pointer"
+									onClick={() => videoRef.current?.requestFullscreen()}
+								/>
+							:
+								<ArrowsPointingOutIcon
+									className="opacity-25"
+								/>
+							}
 
 						</div>
 					</div>)}

--- a/web/src/components/player/components/QualitySelectorComponent.tsx
+++ b/web/src/components/player/components/QualitySelectorComponent.tsx
@@ -31,11 +31,17 @@ const QualitySelectorComponent = (props: QualityComponentProps) => {
 		layerList[0] = <option key="disabled" value="disabled">No Layer Selected</option>
 	}
 
+	const hasLayers = props.layers.length > 1;
+
 	return (
 		<div className="h-full flex">
 			<ChartBarIcon
-				className={props.hasPacketLoss ? "text-orange-600" :""}
-				onClick={() => setIsOpen((prev) => props.layers.length <= 1 ? false : !prev)}/>
+				className={`
+					${ props.hasPacketLoss ? "text-orange-600" : "" }
+					${ hasLayers ? "cursor-pointer" : "opacity-25" }
+				`}
+				onClick={() => setIsOpen((prev) => hasLayers && !prev)}
+			/>
 
 			{isOpen && (
 				


### PR DESCRIPTION
- fade requestPictureInPicture button when not supported (ex. Firefox)
- similarly fade requestFullscreen button (ex. Safari)
- fade quality selector button when not available
- add pointer cursor when these buttons are clickable