### PR TITLE
Make the formatting and syntax of the new FFmpeg command examples more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ the stream MOTD and toggle public/private visibility without leaving the publish
 The following simple example broadcasts `video-test.mp4` to https://b.siobud.com with a Bearer Token of `ffmpeg-test`
 
 ```shell
-ffmpeg -re -i video-test.mp4 -bf 0 -f whip -authorization ffmpeg-test https://b.siobud.com/api/whip
+ffmpeg -re -i video-test.mp4 -bf 0 \
+-f whip -authorization "ffmpeg-test" "https://b.siobud.com/api/whip"
 ```
 
 For now, FFmpeg WHIP only supports H.264 (`libx264`) and Opus and will use them by default if the `-vcodec` and `-acodec`
@@ -85,8 +86,8 @@ options are omitted. However, you can use any H.264 encoder, such as:
 
 ```shell
 ffmpeg -hwaccel vulkan -re -i video-test.mp4 -bf 0 -vcodec h264_vaapi \
-  -vf 'format=nv12|vulkan,hwupload' -init_hw_device vulkan \
-  -f whip -authorization ffmpeg-test https://b.siobud.com/api/whip
+  -vf "format=nv12|vulkan,hwupload" -init_hw_device vulkan \
+  -f whip -authorization "ffmpeg-test" "https://b.siobud.com/api/whip"
 ```
 
 The following complex example broadcasts a test feed to https://b.siobud.com with a Bearer Token of `ffmpeg-test`


### PR DESCRIPTION
...with the old example

I had force-pushed those changes to the previous PR, but you merged it before the changes were pushed. 😁

Rendered version: https://github.com/danielfikko/broadcast-box/tree/README-ffmpeg#ffmpeg-broadcasting.